### PR TITLE
(bug) template name missing from `LoginView.as_view`

### DIFF
--- a/bikeshop/urls.py
+++ b/bikeshop/urls.py
@@ -39,7 +39,7 @@ for routeList in routeLists:
 
 urlpatterns = [
     url(r'^', include(core_urls)),
-    url(r'^login/', LoginView.as_view(), {'template_name': 'login.html'}, name='login'),
+    url(r'^login/', LoginView.as_view(template_name='login.html'), name='login'),
     url(r'^logout/', logout_then_login, name='logout'),
     url(r'^members/', include(member_urls)),
     url(r'^bikes/', include(bike_urls)),


### PR DESCRIPTION
After removing deprecated function view, the `as_view` method needs  the `template_name` parameter.